### PR TITLE
add README.md in crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Read and write ODS files"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/thscharler/spreadsheet-ods"
+readme = "README.md"
 keywords = ["ODS", "spreadsheet"]
 categories = ["parser-implementations"]
 exclude = [


### PR DESCRIPTION
### add README.md in [crates.io](https://crates.io/crates/spreadsheet-ods)
[https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field)
i think the crate must be republished.