### PR TITLE
name is no longer treated as any common attribute and got it's own

### DIFF
--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1267,11 +1267,7 @@ fn write_tablestyle(style: &TableStyle, xml_out: &mut XmlOdsWriter) -> Result<()
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "table")?;
     for (a, v) in style.attrmap().iter() {
@@ -1304,11 +1300,7 @@ fn write_rowstyle(style: &RowStyle, xml_out: &mut XmlOdsWriter) -> Result<(), Od
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "table-row")?;
     for (a, v) in style.attrmap().iter() {
@@ -1341,11 +1333,7 @@ fn write_colstyle(style: &ColStyle, xml_out: &mut XmlOdsWriter) -> Result<(), Od
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "table-column")?;
     for (a, v) in style.attrmap().iter() {
@@ -1378,11 +1366,7 @@ fn write_cellstyle(style: &CellStyle, xml_out: &mut XmlOdsWriter) -> Result<(), 
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "table-cell")?;
     for (a, v) in style.attrmap().iter() {
@@ -1438,11 +1422,7 @@ fn write_paragraphstyle(
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "paragraph")?;
     for (a, v) in style.attrmap().iter() {
@@ -1499,11 +1479,7 @@ fn write_textstyle(style: &TextStyle, xml_out: &mut XmlOdsWriter) -> Result<(), 
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "text")?;
     for (a, v) in style.attrmap().iter() {
@@ -1536,11 +1512,7 @@ fn write_graphicstyle(style: &GraphicStyle, xml_out: &mut XmlOdsWriter) -> Resul
         xml_out.elem("style:default-style")?;
     } else {
         xml_out.elem("style:style")?;
-        if let Some(name) = style.name() {
-            xml_out.attr_esc("style:name", name)?;
-        } else {
-            return Err(OdsError::Ods(format!("No format name for {:?}", style)));
-        }
+        xml_out.attr_esc("style:name", style.name())?;
     }
     xml_out.attr("style:family", "graphic")?;
     for (a, v) in style.attrmap().iter() {
@@ -1558,7 +1530,6 @@ fn write_graphicstyle(style: &GraphicStyle, xml_out: &mut XmlOdsWriter) -> Resul
         for (a, v) in style.graphicstyle().iter() {
             xml_out.attr_esc(a.as_ref(), v.as_str())?;
         }
-        xml_out.end_elem("style:graphic-properties")?;
     }
 
     if style.styleuse() == StyleUse::Default {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,8 +397,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_tablestyle(&mut self, style: TableStyle) -> TableStyleRef {
         let sref = style.style_ref();
-        self.tablestyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.tablestyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -420,8 +419,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_rowstyle(&mut self, style: RowStyle) -> RowStyleRef {
         let sref = style.style_ref();
-        self.rowstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.rowstyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -443,8 +441,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_colstyle(&mut self, style: ColStyle) -> ColStyleRef {
         let sref = style.style_ref();
-        self.colstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.colstyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -466,8 +463,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_cellstyle(&mut self, style: CellStyle) -> CellStyleRef {
         let sref = style.style_ref();
-        self.cellstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.cellstyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -489,8 +485,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_paragraphstyle(&mut self, style: ParagraphStyle) -> ParagraphStyleRef {
         let sref = style.style_ref();
-        self.paragraphstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.paragraphstyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -512,8 +507,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_textstyle(&mut self, style: TextStyle) -> TextStyleRef {
         let sref = style.style_ref();
-        self.textstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.textstyles.insert(style.name().to_string(), style);
         sref
     }
 
@@ -535,8 +529,7 @@ impl WorkBook {
     /// Adds a style.
     pub fn add_graphicstyle(&mut self, style: GraphicStyle) -> GraphicStyleRef {
         let sref = style.style_ref();
-        self.graphicstyles
-            .insert(style.name().unwrap().to_string(), style);
+        self.graphicstyles.insert(style.name().to_string(), style);
         sref
     }
 

--- a/src/style/cellstyle.rs
+++ b/src/style/cellstyle.rs
@@ -44,6 +44,8 @@ pub struct CellStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name.
+    name: String,
     /// General attributes
     attr: AttrMap2,
     //
@@ -60,6 +62,7 @@ impl CellStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             cellstyle: Default::default(),
             paragraphstyle: Default::default(),
@@ -74,20 +77,20 @@ impl CellStyle {
         let mut s = Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             cellstyle: Default::default(),
             paragraphstyle: Default::default(),
             textstyle: Default::default(),
             stylemaps: None,
         };
-        s.set_name(name.into());
         s.set_value_format(value_format);
         s
     }
 
     /// Returns the name as a CellStyleRef.
     pub fn style_ref(&self) -> CellStyleRef {
-        CellStyleRef::from(self.name().unwrap().clone())
+        CellStyleRef::from(self.name())
     }
 
     /// Origin of the style, either styles.xml oder content.xml
@@ -109,13 +112,13 @@ impl CellStyle {
     }
 
     /// Stylename
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Stylename
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     /// Reference to the value format.

--- a/src/style/colstyle.rs
+++ b/src/style/colstyle.rs
@@ -14,6 +14,8 @@ pub struct ColStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -39,6 +41,7 @@ impl ColStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             colstyle: Default::default(),
         }
@@ -46,19 +49,18 @@ impl ColStyle {
 
     /// New Style.
     pub fn new<S: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             colstyle: Default::default(),
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     /// Returns a reference.
     pub fn style_ref(&self) -> ColStyleRef {
-        ColStyleRef::from(self.name().unwrap().clone())
+        ColStyleRef::from(self.name())
     }
 
     /// Origin. Should always be Content.
@@ -82,13 +84,13 @@ impl ColStyle {
     }
 
     /// Name.
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Name.
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     /// Attributes

--- a/src/style/graphicstyle.rs
+++ b/src/style/graphicstyle.rs
@@ -12,6 +12,8 @@ pub struct GraphicStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -36,24 +38,24 @@ impl GraphicStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             graphicstyle: Default::default(),
         }
     }
 
     pub fn new<S: Into<String>, T: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             graphicstyle: Default::default(),
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     pub fn style_ref(&self) -> GraphicStyleRef {
-        GraphicStyleRef::from(self.name().unwrap().clone())
+        GraphicStyleRef::from(self.name())
     }
 
     pub fn origin(&self) -> StyleOrigin {
@@ -72,12 +74,12 @@ impl GraphicStyle {
         self.styleuse = styleuse;
     }
 
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     pub fn attrmap(&self) -> &AttrMap2 {

--- a/src/style/paragraphstyle.rs
+++ b/src/style/paragraphstyle.rs
@@ -22,6 +22,8 @@ pub struct ParagraphStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -49,6 +51,7 @@ impl ParagraphStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             paragraphstyle: Default::default(),
             textstyle: Default::default(),
@@ -57,20 +60,19 @@ impl ParagraphStyle {
     }
 
     pub fn new<S: Into<String>, T: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             paragraphstyle: Default::default(),
             textstyle: Default::default(),
             tabstops: None,
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     pub fn style_ref(&self) -> ParagraphStyleRef {
-        ParagraphStyleRef::from(self.name().unwrap().clone())
+        ParagraphStyleRef::from(self.name())
     }
 
     pub fn origin(&self) -> StyleOrigin {
@@ -89,12 +91,12 @@ impl ParagraphStyle {
         self.styleuse = styleuse;
     }
 
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into()
     }
 
     pub fn display_name(&self) -> Option<&String> {

--- a/src/style/rowstyle.rs
+++ b/src/style/rowstyle.rs
@@ -15,6 +15,8 @@ pub struct RowStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -40,6 +42,7 @@ impl RowStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             rowstyle: Default::default(),
         }
@@ -47,19 +50,18 @@ impl RowStyle {
 
     /// New Style.
     pub fn new<S: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             rowstyle: Default::default(),
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     /// Reference to the style.
     pub fn style_ref(&self) -> RowStyleRef {
-        RowStyleRef::from(self.name().unwrap().clone())
+        RowStyleRef::from(self.name())
     }
 
     /// Origin. Should always be Content.
@@ -83,13 +85,13 @@ impl RowStyle {
     }
 
     /// Name
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Name
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     /// General attributes.

--- a/src/style/tablestyle.rs
+++ b/src/style/tablestyle.rs
@@ -13,6 +13,8 @@ pub struct TableStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -38,6 +40,7 @@ impl TableStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             tablestyle: Default::default(),
         }
@@ -45,19 +48,18 @@ impl TableStyle {
 
     /// Creates a new Style.
     pub fn new<S: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             tablestyle: Default::default(),
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     /// Style reference.
     pub fn style_ref(&self) -> TableStyleRef {
-        TableStyleRef::from(self.name().unwrap().clone())
+        TableStyleRef::from(self.name())
     }
 
     /// Origin of the style.
@@ -81,13 +83,13 @@ impl TableStyle {
     }
 
     /// Style name
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Style name
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     /// Sets the reference to the pageformat.

--- a/src/style/textstyle.rs
+++ b/src/style/textstyle.rs
@@ -17,6 +17,8 @@ pub struct TextStyle {
     origin: StyleOrigin,
     /// Which tag contains this style.
     styleuse: StyleUse,
+    /// Style name
+    name: String,
     /// General attributes
     // ??? style:auto-update 19.467,
     // ??? style:class 19.470,
@@ -40,24 +42,24 @@ impl TextStyle {
         Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: Default::default(),
             attr: Default::default(),
             textstyle: Default::default(),
         }
     }
 
     pub fn new<S: Into<String>, T: Into<String>>(name: S) -> Self {
-        let mut s = Self {
+        Self {
             origin: Default::default(),
             styleuse: Default::default(),
+            name: name.into(),
             attr: Default::default(),
             textstyle: Default::default(),
-        };
-        s.set_name(name.into());
-        s
+        }
     }
 
     pub fn style_ref(&self) -> TextStyleRef {
-        TextStyleRef::from(self.name().unwrap().clone())
+        TextStyleRef::from(self.name())
     }
 
     pub fn origin(&self) -> StyleOrigin {
@@ -76,12 +78,12 @@ impl TextStyle {
         self.styleuse = styleuse;
     }
 
-    pub fn name(&self) -> Option<&String> {
-        self.attr.attr("style:name")
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn set_name<S: Into<String>>(&mut self, name: S) {
-        self.attr.set_attr("style:name", name.into());
+        self.name = name.into();
     }
 
     pub fn display_name(&self) -> Option<&String> {


### PR DESCRIPTION
struct field. this makes handling the empty state a lot easier.
Fixes #20