### PR TITLE
feat: add fn to get attribute of xml tag

### DIFF
--- a/src/xmltree.rs
+++ b/src/xmltree.rs
@@ -113,6 +113,11 @@ impl XmlTag {
         self.content.is_empty()
     }
 
+    /// Gets an attribute
+    pub fn get_attr<'a, S: Into<&'a str>>(&self, name: S) -> Option<&String> {
+        self.attr.attr(name.into())
+    }
+
     pub(crate) fn attrmap(&self) -> &AttrMap2 {
         &self.attr
     }


### PR DESCRIPTION
fixes: #31 

This adds a function `get_attr` to `XmlTag` that just looks up the attribute in its internal `attr`. It does not expose `attr` directly since I wasn't sure whether `attr` should be an implementation detail or not.