### PR TITLE
Fix warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
-///! The configuration format is a convoluted tree of typed key/value pairs.
-///! With some complications.
-///!
-///! This is only used internally and is mapped to WorkBookConfig and
-///! SheetConfig which are more accessible.
-///!
+//! The configuration format is a convoluted tree of typed key/value pairs.
+//! With some complications.
+//!
+//! This is only used internally and is mapped to WorkBookConfig and
+//! SheetConfig which are more accessible.
+//!
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;

--- a/src/ds/detach.rs
+++ b/src/ds/detach.rs
@@ -1,4 +1,4 @@
-///! Allows to detach data and reattach it later.
+//! Allows to detach data and reattach it later.
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug)]

--- a/src/ds/detach.rs
+++ b/src/ds/detach.rs
@@ -153,7 +153,7 @@ mod tests {
     fn test_detach() {
         let mut dd = Detach::new("fop");
 
-        assert_eq!(dd.is_detached(), false);
+        assert!(!dd.is_detached());
 
         assert_eq!(*dd.as_ref(), "fop");
         assert_eq!(*dd.as_mut(), "fop");
@@ -163,11 +163,11 @@ mod tests {
         assert_eq!(*d, "fop");
         assert_eq!(d.trim(), "fop");
 
-        assert_eq!(dd.is_detached(), true);
+        assert!(dd.is_detached());
 
         dd.attach(d);
 
-        assert_eq!(dd.is_detached(), false);
+        assert!(!dd.is_detached());
 
         let tt = dd.take();
 

--- a/src/io/parse.rs
+++ b/src/io/parse.rs
@@ -126,7 +126,7 @@ fn token_bool(input: KSpan<'_>) -> KTokenResult<'_, bool> {
 
 #[inline(always)]
 fn token_i16(input: KSpan<'_>) -> KTokenResult<'_, i16> {
-    let _ = sign_all_digits(input)?;
+    sign_all_digits(input)?;
 
     let result = match unsafe { from_utf8_unchecked(input) }.parse::<i16>() {
         Ok(result) => result,
@@ -140,7 +140,7 @@ fn token_i16(input: KSpan<'_>) -> KTokenResult<'_, i16> {
 
 #[inline(always)]
 fn token_u32(input: KSpan<'_>) -> KTokenResult<'_, u32> {
-    let _ = all_digits(input)?;
+    all_digits(input)?;
 
     let result = match unsafe { from_utf8_unchecked(input) }.parse::<u32>() {
         Ok(result) => result,
@@ -154,7 +154,7 @@ fn token_u32(input: KSpan<'_>) -> KTokenResult<'_, u32> {
 
 #[inline(always)]
 fn token_i32(input: KSpan<'_>) -> KTokenResult<'_, i32> {
-    let _ = sign_all_digits(input)?;
+    sign_all_digits(input)?;
 
     let result = match unsafe { from_utf8_unchecked(input) }.parse::<i32>() {
         Ok(result) => result,
@@ -168,7 +168,7 @@ fn token_i32(input: KSpan<'_>) -> KTokenResult<'_, i32> {
 
 #[inline(always)]
 fn token_i64(input: KSpan<'_>) -> KTokenResult<'_, i64> {
-    let _ = sign_all_digits(input)?;
+    sign_all_digits(input)?;
 
     let result = match unsafe { from_utf8_unchecked(input) }.parse::<i64>() {
         Ok(result) => result,
@@ -269,10 +269,10 @@ fn token_datetime(input: KSpan<'_>) -> KTokenResult<'_, NaiveDateTime> {
         Ok(v) => Ok(v),
         Err(err) => {
             dbg!(&err);
-            return Err(nom::Err::Error(KTokenizerError::new(
+            Err(nom::Err::Error(KTokenizerError::new(
                 RCode::DateTime,
                 input,
-            )));
+            )))
         }
     }
 }
@@ -334,7 +334,7 @@ fn sign_all_digits(input: KSpan<'_>) -> KTokenResult<'_, ()> {
 #[inline(always)]
 pub(crate) fn byte(c: u8) -> impl Fn(KSpan<'_>) -> KTokenizerResult<'_, ()> {
     move |i: KSpan<'_>| {
-        if i.len() > 0 && i[0] == c {
+        if !i.is_empty() && i[0] == c {
             Ok((&i[1..], ()))
         } else {
             Err(nom::Err::Error(KTokenizerError::new(RCode::Byte, i)))
@@ -419,8 +419,8 @@ mod tests {
 
     #[test]
     fn test_bool() -> Result<(), OdsError> {
-        assert_eq!(parse_bool(b"true")?, true);
-        assert_eq!(parse_bool(b"false")?, false);
+        assert!(parse_bool(b"true")?);
+        assert!(!(parse_bool(b"false")?));
         parse_bool(b"ffoso").unwrap_err();
         Ok(())
     }

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -2471,9 +2471,9 @@ fn read_stylemap(xml_tag: &BytesStart<'_>) -> Result<StyleMap, OdsError> {
 }
 
 /// Copies all attributes to the map, excluding "style:name" which is returned.
-fn proc_style_attr<'a>(
+fn proc_style_attr(
     attrmap: &mut AttrMap2,
-    xml_tag: &'a BytesStart<'_>,
+    xml_tag: &BytesStart<'_>,
 ) -> Result<String, OdsError> {
     let mut name = None;
 

--- a/src/io/tmp2zip.rs
+++ b/src/io/tmp2zip.rs
@@ -63,8 +63,8 @@ impl TempZip {
     }
 
     /// Starts a new file inside the zip. Returns a Write for the file.
-    pub(crate) fn start_file<'a>(
-        &'a mut self,
+    pub(crate) fn start_file(
+        &mut self,
         name: &'_ str,
         fopt: FileOptions,
     ) -> Result<TempWrite<'_>, std::io::Error> {

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -84,7 +84,7 @@ fn write_ods_impl<W: Write + Seek>(
     Ok(zip_writer.zip()?)
 }
 
-fn sanity_checks(book: &mut WorkBook) -> Result<(), OdsError> {
+fn sanity_checks(book: &WorkBook) -> Result<(), OdsError> {
     if book.sheets.is_empty() {
         return Err(OdsError::Ods("Workbook contains no sheets.".to_string()));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1152,17 +1152,15 @@ impl Default for WorkBookConfig {
 /// Visibility of a column or row.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)]
+#[derive(Default)]
 pub enum Visibility {
+    #[default]
     Visible,
     Collapsed,
     Filtered,
 }
 
-impl Default for Visibility {
-    fn default() -> Self {
-        Visibility::Visible
-    }
-}
+
 
 impl Display for Visibility {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
@@ -1855,14 +1853,14 @@ impl Sheet {
         value: V,
         style: &CellStyleRef,
     ) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.value = value.into();
         cell.style = Some(style.to_string());
     }
 
     /// Sets a value for the specified cell. Creates a new cell if necessary.
     pub fn set_value<V: Into<Value>>(&mut self, row: u32, col: u32, value: V) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.value = value.into();
     }
 
@@ -1877,7 +1875,7 @@ impl Sheet {
 
     /// Sets a formula for the specified cell. Creates a new cell if necessary.
     pub fn set_formula<V: Into<String>>(&mut self, row: u32, col: u32, formula: V) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.formula = Some(formula.into());
     }
 
@@ -1899,7 +1897,7 @@ impl Sheet {
 
     /// Sets the cell-style for the specified cell. Creates a new cell if necessary.
     pub fn set_cellstyle(&mut self, row: u32, col: u32, style: &CellStyleRef) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.style = Some(style.to_string());
     }
 
@@ -1921,7 +1919,7 @@ impl Sheet {
 
     /// Sets a content-validation for this cell.
     pub fn set_validation(&mut self, row: u32, col: u32, validation: &ValidationRef) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.validation_name = Some(validation.to_string());
     }
 
@@ -1943,7 +1941,7 @@ impl Sheet {
 
     /// Sets the rowspan of the cell. Must be greater than 0.
     pub fn set_row_span(&mut self, row: u32, col: u32, span: u32) {
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.span.row_span = span;
     }
 
@@ -1959,7 +1957,7 @@ impl Sheet {
     /// Sets the colspan of the cell. Must be greater than 0.
     pub fn set_col_span(&mut self, row: u32, col: u32, span: u32) {
         assert!(span > 0);
-        let mut cell = self.data.entry((row, col)).or_insert_with(CellData::new);
+        let cell = self.data.entry((row, col)).or_insert_with(CellData::new);
         cell.span.col_span = span;
     }
 
@@ -2432,7 +2430,9 @@ pub enum ValueType {
 /// Content-Values
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
+#[derive(Default)]
 pub enum Value {
+    #[default]
     Empty,
     Boolean(bool),
     Number(f64),
@@ -2800,11 +2800,7 @@ impl Value {
     }
 }
 
-impl Default for Value {
-    fn default() -> Self {
-        Value::Empty
-    }
-}
+
 
 /// currency value
 #[macro_export]

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -333,7 +333,7 @@ mod conv {
         let mut col = 0u32;
 
         for c in (*i).chars() {
-            if !('A'..='Z').contains(&c) {
+            if !c.is_ascii_uppercase() {
                 return Err(ParseColnameError::InvalidChar);
             }
 
@@ -452,7 +452,7 @@ mod tokens {
             .with_code(CRString),
             pchar(SINGLE_QUOTE).with_code(CRSingleQuoteEnd),
         )))
-        .map(|v| unquote_single(v))
+        .map(unquote_single)
         .parse(input)
     }
 

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -12,6 +12,7 @@ use std::fmt::{Display, Formatter};
 use CRCode::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum CRCode {
     CRNomError,
 
@@ -356,6 +357,7 @@ mod conv {
     }
 }
 
+#[allow(clippy::module_inception)]
 mod parser {
     use crate::refs::parser::tokens::{
         col, dollar_nom, dot, hashtag, row, single_quoted_string, unquoted_sheet_name,

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -137,22 +137,21 @@ mod textstyle;
 
 /// Origin of a style. Content.xml or Styles.xml.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum StyleOrigin {
     /// Style comes from Content.xml
+    #[default]
     Content,
     /// Style comes from Styles.xml
     Styles,
 }
 
-impl Default for StyleOrigin {
-    fn default() -> Self {
-        StyleOrigin::Content
-    }
-}
+
 
 /// Placement of a style. office:styles or office:automatic-styles
 /// Defines the usage pattern for the style.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum StyleUse {
     /// The style:default-style element represents default styles. A default style specifies
     /// default formatting properties for a style family. These defaults are used if a formatting property is
@@ -173,14 +172,11 @@ pub enum StyleUse {
     /// consumers. Common styles present to a user as a named set of formatting
     /// properties. The formatting properties of an automatic style present to a user as
     /// properties of the object to which the style is applied.
+    #[default]
     Automatic,
 }
 
-impl Default for StyleUse {
-    fn default() -> Self {
-        StyleUse::Automatic
-    }
-}
+
 
 /// Parses an attribute string to a value type.
 pub(crate) trait ParseStyleAttr<T> {

--- a/src/style/units.rs
+++ b/src/style/units.rs
@@ -34,8 +34,10 @@ impl Display for Angle {
 /// A (positive or negative) length, consisting of magnitude and unit, in conformance with the Units of
 /// Measure defined in §5.9.13 of XSL.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default)]
 pub enum Length {
     /// Unspecified length, the actual value is some default or whatever.
+    #[default]
     Default,
     /// cm
     Cm(f64),
@@ -66,11 +68,7 @@ impl Length {
     }
 }
 
-impl Default for Length {
-    fn default() -> Self {
-        Length::Default
-    }
-}
+
 
 impl Display for Length {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -12,20 +12,18 @@ use std::str::from_utf8;
 
 /// This defines how lists of entries are displayed to the user.
 #[derive(Copy, Clone, Debug)]
+#[derive(Default)]
 pub enum ValidationDisplay {
     /// Don't show.
     NoDisplay,
     /// Show the entries in the original order.
+    #[default]
     Unsorted,
     /// Sort the entries.
     SortAscending,
 }
 
-impl Default for ValidationDisplay {
-    fn default() -> Self {
-        ValidationDisplay::Unsorted
-    }
-}
+
 
 impl TryFrom<&str> for ValidationDisplay {
     type Error = OdsError;

--- a/tests/bench_fast.rs
+++ b/tests/bench_fast.rs
@@ -61,7 +61,7 @@ fn create_wb(rows: u32, cols: u32) -> impl FnMut() -> Result<WorkBook, OdsError>
     }
 }
 
-fn write_wb<'a>(wb: &'a mut WorkBook) -> impl FnMut() -> Result<(), OdsError> + 'a {
+fn write_wb(wb: &mut WorkBook) -> impl FnMut() -> Result<(), OdsError> + '_ {
     move || {
         let buf = write_ods_buf(wb, Vec::new())?;
         println!("len {}", buf.len());

--- a/tests/sizes.rs
+++ b/tests/sizes.rs
@@ -18,7 +18,7 @@ pub fn sizes() {
     println!("f64 {}", size_of::<f64>());
     println!("f64, [u8; 3] {}", size_of::<(f64, [u8; 3])>());
     println!("f64, String {}", size_of::<(f64, String)>());
-    println!("[u8; 3] {}", size_of::<([u8; 3])>());
+    println!("[u8; 3] {}", size_of::<[u8; 3]>());
     println!("String {}", size_of::<String>());
     println!("Vec<TextTag> {}", size_of::<Vec<TextTag>>());
     println!("NaiveDateTime {}", size_of::<NaiveDateTime>());

--- a/tests/test_style_attr.rs
+++ b/tests/test_style_attr.rs
@@ -1,7 +1,6 @@
 use color::Rgb;
 
-use spreadsheet_ods::condition::{Condition, ValueCondition};
-use spreadsheet_ods::format::ValueStyleMap;
+use spreadsheet_ods::condition::Condition;
 use spreadsheet_ods::style::stylemap::StyleMap;
 use spreadsheet_ods::style::units::{
     Angle, Border, CellAlignVertical, FontFamilyGeneric, FontPitch, FontWeight, Length, PageBreak,

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -1,4 +1,4 @@
-use spreadsheet_ods::condition::{Condition, ValueCondition};
+use spreadsheet_ods::condition::Condition;
 use spreadsheet_ods::text::TextP;
 use spreadsheet_ods::validation::{Validation, ValidationError, ValidationHelp};
 use spreadsheet_ods::{write_ods, CellRange, OdsError, Sheet, WorkBook};

--- a/tests/test_write_read.rs
+++ b/tests/test_write_read.rs
@@ -160,7 +160,7 @@ fn test_write_write() -> Result<(), OdsError> {
     wb.push_sheet(sh);
 
     let v = Cursor::new(Vec::new());
-    let v = write_ods_to(&mut wb, v)?;
+    write_ods_to(&mut wb, v)?;
 
     Ok(())
 }

--- a/tests/test_xparse.rs
+++ b/tests/test_xparse.rs
@@ -3,7 +3,7 @@ use nom::combinator::opt;
 use nom::{AsBytes, AsChar, Parser};
 use std::fmt::{Display, Formatter};
 use std::hint::black_box;
-use std::num::{IntErrorKind, ParseIntError};
+
 use std::str::from_utf8_unchecked;
 use std::time::Instant;
 
@@ -138,7 +138,7 @@ pub fn all_digits(input: &[u8]) -> TokenizerResult<RCode, &[u8], ()> {
 #[inline(always)]
 pub(crate) fn byte(c: u8) -> impl Fn(&[u8]) -> TokenizerResult<RCode, &[u8], ()> {
     move |i: &[u8]| {
-        if i.len() > 0 && i[0] == c {
+        if !i.is_empty() && i[0] == c {
             Ok((&i[1..], ()))
         } else {
             Err(nom::Err::Error(KTokenizerError::new(RCode::Byte, i)))


### PR DESCRIPTION
I noticed a few warnings in the project and decided to fix them.
First I ran `cargo clippy --fix`. I think it contains reasonable changes. Then I resolved [suspicious_doc_comments](https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_doc_comments) manually because `cargo --fix` skips it. And last two warnings I just silenced for now, let me know  if you prefer to fix them properly.