### PR TITLE
deps: enable quick-xml encoding feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ icu_locid = "1.5"
 lazy_static = "1.5"
 kparse = "3.0"
 base64 = "0.22"
-quick-xml = { version = "0.37" }
+quick-xml = { version = "0.37", features = ["encoding"] }
 zip = { version = "2.2.0", default-features = false, features = ["deflate", "time"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "alloc"] }
 get-size = "0.1.4"

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -10,7 +10,7 @@ use std::str::from_utf8;
 use chrono::{Duration, NaiveDateTime};
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::{BytesStart, Event};
-use quick_xml::Decoder;
+use quick_xml::{Decoder, Reader};
 use zip::ZipArchive;
 
 use crate::attrmap2::AttrMap2;
@@ -206,7 +206,7 @@ impl OdsContext {
     fn new(options: &OdsOptions) -> Self {
         Self {
             book: Default::default(),
-            decoder: Decoder {},
+            decoder: Reader::from_reader(Vec::<u8>::new().as_slice()).decoder(),
             content_only: options.content_only,
             use_repeat_for_cells: options.use_repeat_for_cells,
             ignore_empty_cells: options.ignore_empty_cells,


### PR DESCRIPTION
this allows other crates (in particular - calamine) to co-exist with this crate which requires the encoding feature

resolves #58 