### PR TITLE
deps: replace color-rs with color-rs2; remove num-traits pin on 0.2.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,8 @@ dump_unused = []
 [dependencies]
 rust_decimal = { version = "1.36", optional = true }
 rust_decimal_macros = { version = "1.36", optional = true }
-color-rs = { version = "0.8.0" }
-# This exact version is needed for color-rs to compile.
-# 0.2.19 introduced the function that makes it fail.
-num-traits = "=0.2.18"
+color-rs2 = { version = "0.9.0" }
+num-traits = "0.2.19"
 string_cache = "0.8"
 nom = "7.1"
 nom_locate = "4.2"


### PR DESCRIPTION
and bumping to 0.2.19.

[color-rs](https://github.com/arturoc/color-rs) has not been maintained in almost a year, and the fix was never released though it was merged.

See #49

Further, the Issues setting in the repo is not enabled.

Created a renamed fork [color-rs2](https://github.com/jqnatividad/color-rs2) with the num-traits fix, along with some other minor fixes.

This allows the removal of the 0.2.18 pin on the num-traits crate allowing spreadsheet-ods to co-exist with other crates that require num-traits 0.2.19.

