### PR TITLE
Empty text:p tags should be considered newlines (#68)

### DIFF
--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1436,7 +1436,9 @@ fn read_table_cell(
                 println!(" read_table_cell {:?}", evt);
             }
             match &evt {
-                Event::Empty(xml_tag) if xml_tag.name().as_ref() == b"text:p" => {}
+                Event::Empty(xml_tag) if xml_tag.name().as_ref() == b"text:p" => {
+                    tc.content = append_text(TextContent::Text(String::new()), tc.content);
+                }
                 Event::Start(xml_tag) if xml_tag.name().as_ref() == b"text:p" => {
                     let new_txt = read_text_or_tag(ctx, xml, xml_tag, false)?;
                     tc.content = append_text(new_txt, tc.content);

--- a/src/value_.rs
+++ b/src/value_.rs
@@ -330,11 +330,13 @@ impl Value {
             Value::Text(s) => Cow::from(s),
             Value::TextXml(v) => {
                 let mut buf = String::new();
+                let mut add_newline = false;
                 for t in v {
-                    if !buf.is_empty() {
+                    if add_newline {
                         buf.push('\n');
                     }
                     t.extract_text(&mut buf);
+                    add_newline = true;
                 }
                 Cow::from(buf)
             }


### PR DESCRIPTION
Fixes #68

This PR fixes two bugs:

The one reported in #68 plus a similar one where leading newlines would always be ignored. The following file:

[MultlineStartsNewline.ods](https://github.com/user-attachments/files/24039723/MultlineStartsNewline.ods)

Must print (notice the empty newline at the beginning):

```

This is a
Multiline
Example

With an empty newline
```