### PR TITLE
Fix build without default-features

### DIFF
--- a/src/value_.rs
+++ b/src/value_.rs
@@ -2,9 +2,11 @@ use std::borrow::Cow;
 
 use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use get_size2::GetSize;
-use rust_decimal::prelude::FromPrimitive;
-use rust_decimal::prelude::ToPrimitive;
-use rust_decimal::Decimal;
+#[cfg(feature = "rust_decimal")]
+use rust_decimal::{
+    prelude::{FromPrimitive, ToPrimitive},
+    Decimal,
+};
 
 use crate::text::TextTag;
 


### PR DESCRIPTION
Can be tested with:
- `cargo build --no-default-features`
- `cargo test --no-default-features`

Fixes the following error:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rust_decimal`
 --> src/value_.rs:5:5
  |
5 | use rust_decimal::prelude::FromPrimitive;
  |     ^^^^^^^^^^^^ use of unresolved module or unlinked crate `rust_decimal`
  |
  = help: if you wanted to use a crate named `rust_decimal`, use `cargo add rust_decimal` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rust_decimal`
 --> src/value_.rs:6:5
  |
6 | use rust_decimal::prelude::ToPrimitive;
  |     ^^^^^^^^^^^^ use of unresolved module or unlinked crate `rust_decimal`
  |
  = help: if you wanted to use a crate named `rust_decimal`, use `cargo add rust_decimal` to add it to your `Cargo.toml`

error[E0432]: unresolved import `rust_decimal`
 --> src/value_.rs:7:5
  |
7 | use rust_decimal::Decimal;
  |     ^^^^^^^^^^^^ use of unresolved module or unlinked crate `rust_decimal`
  |
  = help: if you wanted to use a crate named `rust_decimal`, use `cargo add rust_decimal` to add it to your `Cargo.toml`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `spreadsheet-ods` (lib) due to 3 previous errors
```
